### PR TITLE
fix(darkTheme): fix when config.base has protocal, generate wrong lin…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-theme",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Vite plugin for dynamically changing the theme color of the interface",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/antdDarkThemePlugin.ts
+++ b/src/antdDarkThemePlugin.ts
@@ -122,7 +122,7 @@ export function antdDarkThemePlugin(options: AntdDarkThemeOption): Plugin[] {
                 rel: 'alternate stylesheet',
                 href: href,
               },
-              injectTo: 'head-prepend',
+              injectTo: 'head',
             },
           ],
         };


### PR DESCRIPTION
**问题描述：**

当使用vben时，配置生成环境变量为：
```javascript
......

# public path, please set to deployed server address
VITE_PUBLIC_PATH = http://localhost:5500/ #此处带上协议信息

......
```
最终打包出的暗黑主题样式为：
```html
......
<link disabled id=__VITE_PLUGIN_THEME-ANTD_DARK_THEME_LINK__ rel="alternate stylesheet" href=http:/localhost:5500/assets/app-antd-dark-theme-style.e3b0c442.css>
......
```
此处http协议少了一个反斜杠，导致资源请求不到。

**问题原因：**

node的path.join方法会将`http://`给过滤成`http:/`，因此需要对添加协议的设置做特殊处理。

**主要修改内容：**

增加针对协议的处理内容，主要修改[src/antdDarkThemePlugin.ts](https://github.com/vbenjs/vite-plugin-theme/compare/main...ZeyanGuo:fix/20220211-protocal-recognized-logic?expand=1#diff-80d251f90cbf67d32301c5ccb622635a24c479a16205cb465718f6b3b1c73597)文件。